### PR TITLE
Accommodate correctly pluralized ViewStrings in GAP

### DIFF
--- a/doc/iso.msk
+++ b/doc/iso.msk
@@ -225,7 +225,7 @@ gap> NrFanoPlanesAtPoints([3],P);
 \Declaration{PRank}
 \beginexample
 gap> G:=CyclicGroup(2^2+3);
-<pc group of size 7 with 1 generators>
+<pc group of size 7 with 1 generator>
 gap> P:=DevelopmentOfRDS(OneDiffset(G),G);;
 gap> IncidenceMatrix(P);
 [ [ 1, 1, 1, 0, 0, 0, 0 ], [ 1, 0, 0, 1, 1, 0, 0 ], [ 0, 1, 0, 1, 0, 1, 0 ], 

--- a/doc/startsets.msk
+++ b/doc/startsets.msk
@@ -227,7 +227,7 @@ Error...
 \Declaration{RemainingCompletions}
 \beginexample
 gap> G:=CyclicGroup(7);
-<pc group of size 7 with 1 generators>
+<pc group of size 7 with 1 generator>
 gap> dat:=PermutationRepForDiffsetCalculations(G);;
 gap> RemainingCompletionsNoSort([4],[1..7],dat);
 [ 2, 3 ]
@@ -284,7 +284,7 @@ gap> m:=[
 > [0,0,0,0,0,0,1],
 > [1,0,0,0,0,0,0]];;
 gap> G:=Group(m);
-<matrix group with 1 generators>
+<matrix group with 1 generator>
 gap> Order(G);
 7
 gap> Size(AllDiffsets(G));

--- a/doc/tutorial.msk
+++ b/doc/tutorial.msk
@@ -17,8 +17,7 @@ easiest way to calculate relative difference sets.
 For a quick start, try this:
 \beginexample
 gap> LoadPackage("rds");;
-gap> G:=CyclicGroup(7);
-<pc group of size 7 with 1 generators>
+gap> G:=CyclicGroup(7);;
 gap> AllDiffsets(G);
 [ [ f1, f1^3 ], [ f1, f1^5 ], [ f1^2, f1^3 ], [ f1^2, f1^6 ], [ f1^4, f1^5 ], 
   [ f1^4, f1^6 ] ]

--- a/tst/manual.example-2.tst
+++ b/tst/manual.example-2.tst
@@ -1,5 +1,4 @@
-gap> G:=CyclicGroup(7);
-<pc group of size 7 with 1 generators>
+gap> G:=CyclicGroup(7);;
 gap> AllDiffsets(G);
 [ [ f1, f1^3 ], [ f1, f1^5 ], [ f1^2, f1^3 ], [ f1^2, f1^6 ], [ f1^4, f1^5 ], 
   [ f1^4, f1^6 ] ]


### PR DESCRIPTION
In a future version of GAP, some nouns will be correctly pluralised to match their number.  For example, the `ViewString` for `CyclicGroup(3);` will change from `<pc group of size 3 with 1 generators>` to `<pc group of size 3 with 1 generator>`.

The changes in this PR maintain the backwards and forwards compatibility of this package with GAP. (As far as I can tell, only the change to the test file is absolutely necessary to maintain compatibility, but I thought why not change the `.msk` files too.)

See gap-system/gap#3992 and gap-system/gap#4050 for more context.